### PR TITLE
Add packageMap option

### DIFF
--- a/tasks/smoothie.js
+++ b/tasks/smoothie.js
@@ -68,8 +68,12 @@ module.exports = function (grunt) {
 			if (answers.moduleName) {
 				options.moduleName = answers.moduleName;
 			}
-			var srcDest = options.src + options.moduleName;
-			var testDest = options.test + options.moduleName;
+			
+			options.package = answers.package || '';
+
+			var srcDest = options.src + options.package + options.moduleName;
+			var testDest = options.test + options.package + options.moduleName;
+			
 			var template = c.getTemplate(options.moduleType, options.flavour, options.moduleTemplate);
 			var content = grunt.template.process(template.call(this, options), { data: options });
 
@@ -101,6 +105,25 @@ module.exports = function (grunt) {
 				},
 				when: function () {
 					return true;
+				}
+			},
+			{
+				type: 'list',
+				name: 'package',
+				message: 'Choose package',
+				choices: options.packageMap.map(function(item) {
+					if(typeof item === 'string') {
+						item = {
+							name: change.ucFirst(item),
+							value: change.lower(item) + '/'
+						}
+					}
+					return item;
+				}),
+				default: '',
+				when: function() {
+					options.package = '';
+					return options.packageMap && options.packageMap.length > 0;
 				}
 			}
 		];


### PR DESCRIPTION
Simple and optional way to map created classes to packages via a 'packageMap' config option, e.g.

packageMap: [
  {
    name: 'Top Level',
    value: ''
  },
  'core',
  'components',
  'states',
  'utils'
]

packageMap is an array of strings or objects (with name shown in list and value of directory path). Strings will be converted in to a name and a directory path (by adding '/' on the end).

If it isn't there or is an empty array, the question is skipped.