### PR TITLE
Fix - map error if packageMap not present

### DIFF
--- a/tasks/smoothie.js
+++ b/tasks/smoothie.js
@@ -54,6 +54,8 @@ module.exports = function (grunt) {
 		var options = this.options({
 			moduleName: 'Example'
 		});
+		
+		options.packageMap = options.packageMap || [];
 
 		var done = this.async();
 


### PR DESCRIPTION
Makes the optional packageMap an empty array if it isn't there. Stops map throwing an error.
